### PR TITLE
Avoid division by zero in the case of duplicate vertices.

### DIFF
--- a/locate_points_core.py
+++ b/locate_points_core.py
@@ -117,7 +117,7 @@ class LocatePointsEngine(object):
             dy = yr - yl
             dl = sqrt(dx**2 + dy**2)
             leftdist = dl - self.partdist
-            while leftdist >= 0:
+            while leftdist >= 0 and dl > 0:
                 pnt = {'distance': self.totaldist}
                 coef = self.partdist / dl
                 pnt['X'] = (1 - coef) * xl + coef * xr


### PR DESCRIPTION
To avoid division by zero distance, skip the interpolation stage for a
vertex at the same location as the preceding vertex.